### PR TITLE
Command executor and Event Listener refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "clap"
-version = "3.2.14"
+version = "3.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54635806b078b7925d6e36810b1755f2a4b5b4d57560432c1ecf60bcbe10602b"
+checksum = "44bbe24bbd31a185bc2c4f7c2abe80bea13a20d57ee4e55be70ac512bdc76417"
 dependencies = [
  "atty",
  "bitflags",
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.7"
+version = "3.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "cdcc2916cde080c1876ff40292a396541241fe0072ef928cd76582e9ea5d60d2"
 dependencies = [
  "unicode-ident",
 ]
@@ -206,18 +206,18 @@ checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "serde"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
+checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
+checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ readme = "README.md"
 exclude = ["img/*"]
 
 [dependencies]
-anyhow = { version = "1" }
-clap = { version = "3", features = ["derive"] }
-i3_ipc = { version = "0.15" }
+anyhow = "1.0.58"
+clap = { version = "3.2.15", features = ["derive"] }
+i3_ipc = "0.15.0"

--- a/src/command_executor.rs
+++ b/src/command_executor.rs
@@ -1,0 +1,98 @@
+/*
+   Copyright (C) 2022  Biagio Festa
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+use std::fmt::Display;
+
+use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Result;
+use i3_ipc::Connect;
+use i3_ipc::I3Stream;
+use i3_ipc::I3;
+
+pub type I3Version = i3_ipc::reply::Version;
+pub type I3Workspace = i3_ipc::reply::Workspace;
+pub type I3Node = i3_ipc::reply::Node;
+
+pub struct CommandExecutor {
+    i3_stream: I3Stream,
+}
+
+impl CommandExecutor {
+    pub fn new() -> Result<Self> {
+        println!("Creating command executor...");
+        let i3_stream = I3::connect().context("Cannot create command executor")?;
+        println!("  Ok");
+
+        Ok(Self { i3_stream })
+    }
+
+    pub fn run<C>(&mut self, command: C) -> Result<()>
+    where
+        C: AsRef<str>,
+    {
+        let response = self
+            .i3_stream
+            .run_command(command)
+            .context("Cannot execute the command")?;
+
+        for resp in response.into_iter() {
+            if !resp.success {
+                return Err(anyhow!(
+                    "Command execution returned a failure response: '{}'",
+                    resp.error.unwrap_or_else(|| "N/A".to_string())
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn run_on_node_id<C>(&mut self, node_id: usize, command: C) -> Result<()>
+    where
+        C: Display,
+    {
+        self.run(format!("[con_id={}] {}", node_id, command))
+    }
+    pub fn query_workspaces(&mut self) -> Result<Vec<I3Workspace>> {
+        self.i3_stream
+            .get_workspaces()
+            .context("Cannot query i3 workspaces")
+    }
+
+    pub fn query_root_node(&mut self) -> Result<RootNode> {
+        Ok(RootNode(
+            self.i3_stream
+                .get_tree()
+                .context("Cannot query i3 root-node")?,
+        ))
+    }
+
+    pub fn query_i3_version(&mut self) -> Result<I3Version> {
+        self.i3_stream
+            .get_version()
+            .context("Cannot query i3 version")
+    }
+}
+
+pub struct RootNode(I3Node);
+
+impl RootNode {
+    pub fn i3_node(&self) -> &I3Node {
+        &self.0
+    }
+}

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -1,0 +1,62 @@
+/*
+    Copyright (C) 2022  Biagio Festa
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+use anyhow::Context;
+use anyhow::Result;
+use i3_ipc::event::Subscribe;
+use i3_ipc::I3Stream;
+
+pub type Event = i3_ipc::event::Event;
+
+#[derive(Copy, Clone)]
+pub enum EventSubscribe {
+    Window,
+}
+
+pub struct EventListener {
+    i3_stream: I3Stream,
+}
+
+impl EventListener {
+    pub fn new(event_subscribe: &[EventSubscribe]) -> Result<Self> {
+        println!("Creating event listener...");
+        let i3_stream = I3Stream::conn_sub(
+            event_subscribe
+                .iter()
+                .map(|&e| e.into())
+                .collect::<Vec<_>>(),
+        )
+        .context("Cannot create event listener")?;
+        println!("  Ok");
+
+        Ok(Self { i3_stream })
+    }
+
+    pub fn receive_event(&mut self) -> Result<Event> {
+        self.i3_stream
+            .receive_event()
+            .context("Cannot receive event from i3 listener")
+    }
+}
+
+impl From<EventSubscribe> for Subscribe {
+    fn from(e: EventSubscribe) -> Self {
+        match e {
+            EventSubscribe::Window => Subscribe::Window,
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,37 +15,74 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+use crate::autolayout::AutoLayout;
+use crate::command_executor::CommandExecutor;
+use crate::event_listener::EventListener;
+use crate::event_listener::EventSubscribe;
+use crate::tabmode::TabMode;
+use anyhow::Context;
 use anyhow::Result;
-use autolayout::AutoLayout;
 use clap::Parser;
-use clap::Subcommand;
-use tabmode::TabMode;
 
-#[derive(Parser)]
-#[clap(author, version, about)]
+#[derive(clap::Parser)]
+#[clap(about, author, version)]
 struct CliArgs {
     #[clap(subcommand)]
     command: Command,
 }
 
-#[derive(Subcommand)]
+#[derive(clap::Subcommand)]
 enum Command {
     #[clap(name = "autolayout")]
     Autolayout,
 
     #[clap(name = "tabmode")]
     TabMode,
+
+    #[clap(name = "i3version")]
+    I3Version,
 }
 
 fn main() -> Result<()> {
     let cli_args = CliArgs::parse();
 
     match cli_args.command {
-        Command::Autolayout => AutoLayout::new()?.serve(),
-        Command::TabMode => TabMode::new()?.execute(),
+        Command::Autolayout => command_autolayout().context("Failure in command 'autolayout'"),
+        Command::TabMode => command_tabmode().context("Failure in command 'tabmode'"),
+        Command::I3Version => command_i3_version().context("Failure in command 'i3version'"),
     }
 }
 
+fn command_autolayout() -> Result<()> {
+    let event_listener = EventListener::new(&[EventSubscribe::Window])?;
+    let command_executor = CommandExecutor::new()?;
+    let autolayout = AutoLayout::new(event_listener, command_executor);
+
+    autolayout.serve()
+}
+
+fn command_tabmode() -> Result<()> {
+    let command_executor = CommandExecutor::new()?;
+    let tabmode = TabMode::new(command_executor);
+
+    tabmode.execute()
+}
+
+fn command_i3_version() -> Result<()> {
+    let mut command_executor = CommandExecutor::new()?;
+    let i3_version = command_executor.query_i3_version()?;
+
+    println!(
+        "I3 version: '{}'\n\
+         Config File: '{}'",
+        i3_version.human_readable, i3_version.loaded_config_file_name
+    );
+
+    Ok(())
+}
+
 mod autolayout;
+mod command_executor;
+mod event_listener;
 mod tabmode;
 mod utilities;

--- a/src/tabmode.rs
+++ b/src/tabmode.rs
@@ -15,21 +15,22 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-use crate::utilities::execute_i3_command;
+use crate::command_executor::CommandExecutor;
+use crate::command_executor::I3Node;
+use crate::command_executor::RootNode;
+use crate::utilities::find_node_by_id;
+use crate::utilities::set_node_layout;
+use crate::utilities::Layout;
 use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
-use i3_ipc::reply::Node;
-use i3_ipc::Connect;
-use i3_ipc::I3Stream;
-use i3_ipc::I3;
 
 /// TabMode executor.
 ///
 /// It represent a one-shot executor which normalizes the current active workspace
 /// and display all nodes in tabbed mode.
 pub struct TabMode {
-    i3_stream: I3Stream,
+    command_executor: CommandExecutor,
 }
 
 impl TabMode {
@@ -38,107 +39,70 @@ impl TabMode {
     /// Initialize and the create the executor.
     ///
     /// It connects to i3 IPC.
-    pub fn new() -> Result<Self> {
-        I3::connect()
-            .context("Cannot connect to I3")
-            .map(|i3_stream| Self { i3_stream })
+    pub fn new(command_executor: CommandExecutor) -> Self {
+        Self { command_executor }
     }
 
     /// Execute the action.
     ///
     /// It normalizes the current active workspace and displays all nodes
     /// it a tabbed layout.
-    pub fn execute(&mut self) -> Result<()> {
-        let workspace = self.get_focus_workspace()?;
-        let workspace_id = workspace.id;
+    pub fn execute(mut self) -> Result<()> {
+        let root_node = self.command_executor.query_root_node()?;
+        let workspace = self.get_focus_workspace(&root_node)?;
 
         self.normalize_workspace(workspace)?;
 
-        execute_i3_command(
-            &mut self.i3_stream,
-            format!("[con_id={}] layout tabbed", workspace_id),
-        )
-        .context("Cannot set tabbed layout on workspace")?;
-
-        Ok(())
+        set_node_layout(workspace.id, Layout::Tabbed, &mut self.command_executor)
+            .context("Cannot layout for focused workspace")
     }
 
-    fn get_focus_workspace(&mut self) -> Result<Node> {
-        let workspace_id = self
-            .i3_stream
-            .get_workspaces()
-            .context("Cannot get list of workspaces from I3")?
+    fn get_focus_workspace<'a>(&mut self, root_node: &'a RootNode) -> Result<&'a I3Node> {
+        let focused_workspace_id = self
+            .command_executor
+            .query_workspaces()?
             .into_iter()
             .find(|workspace| workspace.focused)
-            .ok_or_else(|| anyhow!("Cannot detect the active workspace"))?
+            .ok_or_else(|| anyhow!("Cannot detect the current focused workspace"))?
             .id;
 
-        let root = self
-            .i3_stream
-            .get_tree()
-            .context("Cannot obtain the tree root")?;
+        find_node_by_id(focused_workspace_id, root_node)
+            .ok_or_else(|| anyhow!("Cannot find focused workspace associated with the id"))
+    }
 
-        let mut dfs = vec![root];
+    fn normalize_workspace(&mut self, workspace: &I3Node) -> Result<()> {
+        self.command_executor
+            .run_on_node_id(workspace.id, format!("mark \"{}\"", Self::MARK_ID))
+            .context("Cannot set temporary mark on focused workspace")?;
 
-        while let Some(current) = dfs.pop() {
-            if current.id == workspace_id {
-                return Ok(current);
-            }
+        let subtree = workspace
+            .nodes
+            .iter()
+            .fold(Vec::new(), |mut subtree, node| {
+                subtree.extend(node.nodes.as_slice());
+                subtree
+            });
 
-            dfs.extend(current.nodes);
+        let move_result = self.move_recursively_on_mark(subtree, Self::MARK_ID);
+
+        self.command_executor
+            .run(format!("unmark \"{}\"", Self::MARK_ID))
+            .context("Cannot unset temporary mark")?;
+
+        move_result
+    }
+
+    fn move_recursively_on_mark(&mut self, mut subtree: Vec<&I3Node>, mark_id: &str) -> Result<()> {
+        while let Some(current) = subtree.pop() {
+            let _ = set_node_layout(current.id, Layout::Default, &mut self.command_executor);
+
+            self.command_executor
+                .run_on_node_id(current.id, format!("move window to mark \"{}\"", mark_id))
+                .context("Cannot mode window on mark")?;
+
+            subtree.extend(current.nodes.as_slice());
         }
 
-        Err(anyhow!("Cannot find workspace associated with id"))
-    }
-
-    fn set_default_layout(&mut self, node: &Node) -> Result<()> {
-        execute_i3_command(
-            &mut self.i3_stream,
-            format!("[con_id={}] layout default", node.id),
-        )
-        .context("Cannot set default layout for node")
-    }
-
-    fn normalize_workspace(&mut self, workspace: Node) -> Result<()> {
-        execute_i3_command(
-            &mut self.i3_stream,
-            format!("[con_id={}] mark \"{}\"", workspace.id, Self::MARK_ID),
-        )
-        .context("Cannot set temporary mark")?;
-
-        let normalize_result = || -> Result<()> {
-            let mut dfs = workspace
-                .nodes
-                .into_iter()
-                .fold(Vec::new(), |mut dfs, node| {
-                    let _ = self.set_default_layout(&node);
-
-                    dfs.extend(node.nodes);
-                    dfs
-                });
-
-            while let Some(current) = dfs.pop() {
-                let _ = self.set_default_layout(&current);
-
-                execute_i3_command(
-                    &mut self.i3_stream,
-                    format!(
-                        "[con_id={}] move window to mark \"{}\"",
-                        current.id,
-                        Self::MARK_ID
-                    ),
-                )
-                .context("Cannot move window")?;
-
-                dfs.extend(current.nodes);
-            }
-
-            Ok(())
-        }();
-
-        execute_i3_command(&mut self.i3_stream, format!("unmark \"{}\"", Self::MARK_ID))
-            .context("Cannot remove temporary mark")?;
-
-        normalize_result
+        Ok(())
     }
 }

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -15,31 +15,104 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-use anyhow::anyhow;
+use crate::command_executor::CommandExecutor;
+use crate::command_executor::I3Node;
+use crate::command_executor::RootNode;
 use anyhow::Context;
 use anyhow::Result;
-use i3_ipc::I3Stream;
+use i3_ipc::reply::NodeType;
 
-/// Execute i3 command.
-pub fn execute_i3_command<S>(i3_stream: &mut I3Stream, command: S) -> Result<()>
-where
-    S: AsRef<str>,
-{
-    i3_stream
-        .run_command(command)
-        .context("Cannot execute command")?
-        .into_iter()
-        .map(|result| {
-            if result.success {
-                Ok(())
-            } else {
-                Err(anyhow!(
-                    "Command failed with: {}",
-                    result.error.unwrap_or_else(|| "N/A".to_string())
-                ))
-            }
-        })
-        .collect::<Result<Vec<_>>>()?;
+pub enum Layout {
+    Default,
+    Tabbed,
+}
 
-    Ok(())
+pub enum Split {
+    Horizontal,
+    Vertical,
+}
+
+pub fn find_node_by_id(node_id: usize, root_node: &RootNode) -> Option<&I3Node> {
+    let mut dfs = vec![root_node.i3_node()];
+
+    while let Some(current) = dfs.pop() {
+        if current.id == node_id {
+            return Some(current);
+        }
+
+        dfs.extend(current.nodes.as_slice())
+    }
+
+    None
+}
+
+pub fn find_node_parent(node_id: usize, root_node: &RootNode) -> Option<&I3Node> {
+    // It's not a real problem, but a waste of CPU cycles
+    debug_assert!(node_id != root_node.i3_node().id);
+
+    let mut dfs: Vec<(&I3Node, &I3Node)> = root_node
+        .i3_node()
+        .nodes
+        .iter()
+        .map(|n| (n, root_node.i3_node()))
+        .collect();
+
+    while let Some((current, parent)) = dfs.pop() {
+        if current.id == node_id {
+            return Some(parent);
+        }
+
+        dfs.extend(current.nodes.iter().map(|n| (n, current)));
+    }
+
+    None
+}
+
+pub fn find_workspace_of_node(node_id: usize, root_node: &RootNode) -> Option<&I3Node> {
+    let mut workspace = None;
+    let mut dfs = vec![root_node.i3_node()];
+
+    while let Some(current) = dfs.pop() {
+        if current.node_type == NodeType::Workspace {
+            workspace = Some(current);
+        }
+
+        if current.id == node_id {
+            break;
+        }
+
+        dfs.extend(current.nodes.as_slice());
+    }
+
+    workspace
+}
+
+pub fn set_node_layout(
+    node_id: usize,
+    layout: Layout,
+    command_executor: &mut CommandExecutor,
+) -> Result<()> {
+    let layout_cmd = match layout {
+        Layout::Default => "layout default",
+        Layout::Tabbed => "layout tabbed",
+    };
+
+    command_executor
+        .run_on_node_id(node_id, layout_cmd)
+        .with_context(|| format!("Cannot set layout for a node ('{}')", layout_cmd))
+}
+
+pub fn set_node_split(
+    node_id: usize,
+    split: Split,
+    command_executor: &mut CommandExecutor,
+) -> Result<()> {
+    let split_cmd = match split {
+        Split::Horizontal => "split horizontal",
+        Split::Vertical => "split vertical",
+    };
+
+    command_executor
+        .run_on_node_id(node_id, split_cmd)
+        .with_context(|| format!("Cannot split a node ('{}')", split_cmd))
 }


### PR DESCRIPTION
This should fix the issue https://github.com/BiagioFesta/i3-autolayout/issues/2

---

* New subcommand from CLI to take i3 information, that is, `i3version`.
* [**bugfix**] New wrapper for I3 connection to separate events and replies. This fixes an issue when events and replies were interleaved on the same i3 connection. Now two different connections avoid collisions.
* Cargo.lock update
* General refactoring with common code in the util-module.
  - Some performance improvements, code optimization on the tree searches.