### PR TITLE
Fix floating containers and more resilent service

### DIFF
--- a/src/autolayout.rs
+++ b/src/autolayout.rs
@@ -20,6 +20,7 @@ use crate::command_executor::I3Node;
 use crate::event_listener::EventListener;
 use crate::utilities::find_node_parent;
 use crate::utilities::find_workspace_of_node;
+use crate::utilities::is_floating_container;
 use crate::utilities::set_node_split;
 use crate::utilities::Split;
 use anyhow::anyhow;
@@ -94,6 +95,10 @@ impl AutoLayout {
     }
 
     fn on_window_focus(&mut self, node: &I3Node) -> Result<()> {
+        if is_floating_container(node) {
+            return Ok(());
+        }
+
         let root_node = self.command_executor.query_root_node()?;
         let parent_node = find_node_parent(node.id, &root_node)
             .ok_or_else(|| anyhow!("Cannot find parent of focused window"))?;

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -20,6 +20,7 @@ use crate::command_executor::I3Node;
 use crate::command_executor::RootNode;
 use anyhow::Context;
 use anyhow::Result;
+use i3_ipc::reply::Floating;
 use i3_ipc::reply::NodeType;
 
 pub enum Layout {
@@ -115,4 +116,11 @@ pub fn set_node_split(
     command_executor
         .run_on_node_id(node_id, split_cmd)
         .with_context(|| format!("Cannot split a node ('{}')", split_cmd))
+}
+
+pub fn is_floating_container(node: &I3Node) -> bool {
+    match node.floating {
+        Some(Floating::AutoOn) | Some(Floating::UserOn) => true,
+        None | Some(Floating::AutoOff) | Some(Floating::UserOff) => false,
+    }
 }


### PR DESCRIPTION
* Avoid autolayout logic on floating containers.
* Report a warning in case of error and avoid crashing the application.
  - So it will retry with new events.