### PR TITLE
New feature: save and restore layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
 
 [[package]]
 name = "arrayvec"
@@ -72,9 +72,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.15"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bbe24bbd31a185bc2c4f7c2abe80bea13a20d57ee4e55be70ac512bdc76417"
+checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
 dependencies = [
  "atty",
  "bitflags",
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.15"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
+checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "lazy_static"
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
 
 [[package]]
 name = "linked-hash-map"
@@ -363,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -440,9 +440,9 @@ checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "serde"
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ad84e47328a31223de7fed7a4f5087f2d6ddfe586cf3ca25b7a165bc0a5aed"
+checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -528,9 +528,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -554,18 +554,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -592,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde 1.0.143",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,7 +118,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "nom",
  "rust-ini",
- "serde 1.0.140",
+ "serde 1.0.143",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -179,9 +188,12 @@ name = "i3-autolayout"
 version = "0.2.2"
 dependencies = [
  "anyhow",
+ "bincode",
  "clap",
  "i3_ipc",
  "ptree",
+ "serde 1.0.143",
+ "serde_json",
 ]
 
 [[package]]
@@ -191,7 +203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2527c88ee03497ce301b75d4d91af96f945131f407258a2cd7473131d7fc2698"
 dependencies = [
  "i3ipc-types",
- "serde 1.0.140",
+ "serde 1.0.143",
  "serde_json",
 ]
 
@@ -201,7 +213,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02f2ba260abda862b5d62cd7c8496d56da773737f5ca751f8ef501cedf8ada20"
 dependencies = [
- "serde 1.0.140",
+ "serde 1.0.143",
  "serde_json",
  "serde_repr",
 ]
@@ -369,7 +381,7 @@ dependencies = [
  "config",
  "directories",
  "petgraph",
- "serde 1.0.140",
+ "serde 1.0.143",
  "serde-value",
  "tint",
 ]
@@ -440,9 +452,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.140"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 dependencies = [
  "serde_derive",
 ]
@@ -466,14 +478,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
- "serde 1.0.140",
+ "serde 1.0.143",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.140"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -482,13 +494,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.140",
+ "serde 1.0.143",
 ]
 
 [[package]]
@@ -575,7 +587,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
- "serde 1.0.140",
+ "serde 1.0.143",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ exclude = ["img/*"]
 
 [dependencies]
 anyhow = "1.0.58"
+bincode = "1.3.3"
 clap = { version = "3.2.15", features = ["derive"] }
 i3_ipc = "0.15.0"
 ptree = "0.4.0"
+serde = { version = "1.0.143", features = ["derive"] }
+serde_json = "1.0.83"

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,9 +66,11 @@ enum Command {
     #[clap(name = "print-tree")]
     PrintTree(PrintTreeCmd),
 
+    /// Save a workspace's layout.
     #[clap(name = "save-layout")]
     SaveLayout(SaveLayoutCmd),
 
+    /// Restore a workspace's layout.
     #[clap(name = "restore-layout")]
     RestoreLayout(RestoreLayoutCmd),
 }
@@ -186,6 +188,7 @@ fn command_print_tree(print_tree_cmd: PrintTreeCmd) -> Result<()> {
     print_tree(node)
 }
 
+/// Save a layout for a workspace.
 fn command_save_layout(save_layout_cmd: SaveLayoutCmd) -> Result<()> {
     let command_executor = CommandExecutor::new()?;
     let save_layout = SaveLayout::new(command_executor);
@@ -202,6 +205,7 @@ fn command_save_layout(save_layout_cmd: SaveLayoutCmd) -> Result<()> {
     save_layout.execute(save_layout_cmd.workspace_num, output, save_layout_cmd.json)
 }
 
+/// Restore a previously saved layout on a workspace.
 fn command_restore_layout(restore_layout_cmd: RestoreLayoutCmd) -> Result<()> {
     let command_executor = CommandExecutor::new()?;
     let restore_layout = RestoreLayout::new(command_executor);

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,10 @@ struct RestoreLayoutCmd {
     /// Whether the input is JSON format.
     #[clap(short, long, action)]
     json: bool,
+
+    /// Whether to attempt to restore sizes of windows.
+    #[clap(short, long, action)]
+    restore_sizes: bool,
 }
 
 fn main() -> Result<()> {
@@ -219,7 +223,11 @@ fn command_restore_layout(restore_layout_cmd: RestoreLayoutCmd) -> Result<()> {
             None => Box::new(std::io::stdin()),
         };
 
-    restore_layout.execute(input, restore_layout_cmd.json)
+    restore_layout.execute(
+        input,
+        restore_layout_cmd.json,
+        restore_layout_cmd.restore_sizes,
+    )
 }
 
 mod autolayout;

--- a/src/print_tree.rs
+++ b/src/print_tree.rs
@@ -38,11 +38,13 @@ impl<'a> TreeItem for TreeNode<'a> {
         W: Write,
     {
         write!(f,
-               "[Type: {type:?}; \
+               "[ID: {id}; \
+                Type: {type:?}; \
                 Name: {name:?}; \
                 Layout: {layout:?}; \
                 WinType: {wintype:?}; \
                 NumFloatings: {num_floats}]",
+               id = self.0.id,
                type = self.0.node_type,
                name = self.0.name,
                layout = self.0.layout,

--- a/src/restore_layout.rs
+++ b/src/restore_layout.rs
@@ -67,9 +67,7 @@ impl RestoreLayout {
                 path.push((saved_node.id(), saved_node.layout()));
 
                 for &child_id in saved_node.children().iter().rev() {
-                    let child = saved_layout.lookup_by_id(child_id).ok_or_else(|| {
-                        anyhow!("Invalid layout. Index is missing for node '{}'", child_id)
-                    })?;
+                    let child = saved_layout.lookup_by_id(child_id);
 
                     dfs.push((child, path.clone()));
                 }

--- a/src/restore_layout.rs
+++ b/src/restore_layout.rs
@@ -1,0 +1,150 @@
+/*
+    Copyright (C) 2022  Biagio Festa
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+use crate::command_executor::CommandExecutor;
+use crate::save_layout::KindNode;
+use crate::save_layout::LayoutNode;
+use crate::save_layout::SavedLayout;
+use crate::utilities::find_node_by_id;
+use crate::utilities::find_node_parent;
+use crate::utilities::find_workspace_by_num;
+use crate::utilities::set_node_layout;
+use crate::utilities::set_node_split;
+use crate::utilities::Layout;
+use crate::utilities::Split;
+use anyhow::anyhow;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::io::Read;
+
+type NodeId = usize;
+
+pub struct RestoreLayout {
+    command_executor: CommandExecutor,
+}
+
+impl RestoreLayout {
+    pub fn new(command_executor: CommandExecutor) -> Self {
+        Self { command_executor }
+    }
+
+    pub fn execute<R>(mut self, reader: R, json_input: bool) -> Result<()>
+    where
+        R: Read,
+    {
+        let saved_layout = SavedLayout::deserialize(reader, json_input)?;
+
+        let workspace_num = match saved_layout.root().kind() {
+            KindNode::Workspace(workspace_num) => Ok(*workspace_num),
+            _ => Err(anyhow!("Invalid layout. Workspace is missing")),
+        }?;
+
+        let mut created_paths = HashMap::new();
+        let mut dfs = vec![(saved_layout.root(), Vec::<(NodeId, LayoutNode)>::new())];
+
+        while let Some((saved_node, mut path)) = dfs.pop() {
+            if saved_node.children().is_empty() {
+                let node_exists = self.move_node_on_ws_if_exists(saved_node.id(), workspace_num)?;
+
+                if node_exists {
+                    self.create_path_tree_for_node(saved_node.id(), &path, &mut created_paths)?;
+                }
+            } else {
+                path.push((saved_node.id(), saved_node.layout()));
+
+                for &child_id in saved_node.children().iter().rev() {
+                    let child = saved_layout.lookup_by_id(child_id).ok_or_else(|| {
+                        anyhow!("Invalid layout. Index is missing for node '{}'", child_id)
+                    })?;
+
+                    dfs.push((child, path.clone()));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn move_node_on_ws_if_exists(&mut self, node_id: usize, workspace_num: i32) -> Result<bool> {
+        const MARK_ID: &str = "MARK_TMP_RESTORE";
+
+        let root_node = self.command_executor.query_root_node()?;
+
+        if find_node_by_id(node_id, &root_node).is_some() {
+            self.command_executor
+                .run_on_node_id(node_id, format!("move to workspace {}", workspace_num))?;
+
+            let workspace = find_workspace_by_num(&root_node, workspace_num)
+                .expect("Expected WS to exist after move on it");
+            self.command_executor
+                .run_on_node_id(workspace.id, format!("mark {}", MARK_ID))?;
+
+            let _ = self
+                .command_executor
+                .run_on_node_id(node_id, format!("move to mark {}", MARK_ID));
+
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn create_path_tree_for_node(
+        &mut self,
+        node_id: usize,
+        path: &[(NodeId, LayoutNode)],
+        created_paths: &mut HashMap<NodeId, NodeId>,
+    ) -> Result<()> {
+        const MARK_ID: &str = "MARK_MOVE";
+
+        let mut last_id = node_id;
+
+        for (split_id, split_layout) in path.iter().skip(1).rev() {
+            match created_paths.get(split_id) {
+                Some(&new_splitter_id) => {
+                    self.command_executor
+                        .run_on_node_id(new_splitter_id, format!("mark {}", MARK_ID))?;
+
+                    self.command_executor
+                        .run_on_node_id(last_id, format!("move to mark {}", MARK_ID))?;
+
+                    return Ok(());
+                }
+                None => {
+                    let layout = match split_layout {
+                        LayoutNode::SplitH => Layout::SplitH,
+                        LayoutNode::SplitV => Layout::SplitV,
+                        LayoutNode::Stacked => Layout::Stacked,
+                        LayoutNode::Tabbed => Layout::Tabbed,
+                    };
+
+                    set_node_split(last_id, Split::Horizontal, &mut self.command_executor)?;
+                    set_node_layout(last_id, layout, &mut self.command_executor)?;
+
+                    let root_node = self.command_executor.query_root_node()?;
+                    last_id = find_node_parent(last_id, &root_node)
+                        .expect("Expected parent just created")
+                        .id;
+
+                    created_paths.insert(*split_id, last_id);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/restore_layout.rs
+++ b/src/restore_layout.rs
@@ -33,20 +33,27 @@ use std::io::Read;
 
 type NodeId = usize;
 
+/// RestoreLayout executor.
+///
+/// Restore a previosly saved layout for a workspace.
 pub struct RestoreLayout {
     command_executor: CommandExecutor,
 }
 
 impl RestoreLayout {
+    /// Construct the new executor.
     pub fn new(command_executor: CommandExecutor) -> Self {
         Self { command_executor }
     }
 
-    pub fn execute<R>(mut self, reader: R, json_input: bool) -> Result<()>
+    /// It reads the saved workspace from `input`.
+    ///
+    /// Then it tries to restore the layout saved with a best-effort approach.
+    pub fn execute<R>(mut self, input: R, json_input: bool) -> Result<()>
     where
         R: Read,
     {
-        let saved_layout = SavedLayout::deserialize(reader, json_input)?;
+        let saved_layout = SavedLayout::deserialize(input, json_input)?;
 
         let workspace_num = match saved_layout.root().kind() {
             KindNode::Workspace(workspace_num) => Ok(*workspace_num),

--- a/src/restore_layout.rs
+++ b/src/restore_layout.rs
@@ -43,8 +43,8 @@ pub struct RestoreLayout {
 }
 
 impl RestoreLayout {
-    const SLEEPTIME_BEFORE_RESIZE: Duration = Duration::from_millis(100);
-    const SLEEPTIME_INTRA_RESIZE: Duration = Duration::from_micros(50);
+    const SLEEPTIME_BEFORE_RESIZE: Duration = Duration::from_millis(200);
+    const SLEEPTIME_INTRA_RESIZE: Duration = Duration::from_micros(200);
 
     /// Construct the new executor.
     pub fn new(command_executor: CommandExecutor) -> Self {
@@ -54,7 +54,7 @@ impl RestoreLayout {
     /// It reads the saved workspace from `input`.
     ///
     /// Then it tries to restore the layout saved with a best-effort approach.
-    pub fn execute<R>(mut self, input: R, json_input: bool) -> Result<()>
+    pub fn execute<R>(mut self, input: R, json_input: bool, restore_sizes: bool) -> Result<()>
     where
         R: Read,
     {
@@ -95,10 +95,12 @@ impl RestoreLayout {
             }
         }
 
-        std::thread::sleep(Self::SLEEPTIME_BEFORE_RESIZE);
+        if restore_sizes {
+            std::thread::sleep(Self::SLEEPTIME_BEFORE_RESIZE);
 
-        self.restore_sizes(&saved_layout)
-            .context("Cannot restore sizes of layout")?;
+            self.restore_sizes(&saved_layout)
+                .context("Cannot restore sizes of layout")?;
+        }
 
         Ok(())
     }

--- a/src/save_layout.rs
+++ b/src/save_layout.rs
@@ -269,7 +269,7 @@ pub enum KindNode {
     Workspace(WorkspaceNum),
 
     /// The node is a normal window (leaf of the tree).
-    NormalWindow,
+    NormalWindow(SavedWindow),
 
     /// The node is a container (children >= 1; intermediate node in tree).
     Splitter,
@@ -285,7 +285,10 @@ impl KindNode {
 
             I3NodeType::Con => {
                 if node.nodes.is_empty() {
-                    Ok(Self::NormalWindow)
+                    Ok(Self::NormalWindow(SavedWindow {
+                        width: node.window_rect.width,
+                        height: node.window_rect.height,
+                    }))
                 } else {
                     Ok(Self::Splitter)
                 }
@@ -293,5 +296,22 @@ impl KindNode {
 
             _ => Err(anyhow!("Unexpected node type: '{:?}'", node.node_type)),
         }
+    }
+}
+
+/// Information about the saved window.
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct SavedWindow {
+    width: isize,
+    height: isize,
+}
+
+impl SavedWindow {
+    pub fn width(&self) -> isize {
+        self.width
+    }
+
+    pub fn height(&self) -> isize {
+        self.height
     }
 }

--- a/src/save_layout.rs
+++ b/src/save_layout.rs
@@ -207,7 +207,7 @@ impl TryFrom<I3NodeLayout> for LayoutNode {
             I3NodeLayout::SplitV => Ok(LayoutNode::SplitV),
             I3NodeLayout::Stacked => Ok(LayoutNode::Stacked),
             I3NodeLayout::Tabbed => Ok(LayoutNode::Tabbed),
-            _ => Err(anyhow!("Unexpcted layout to save: '{:?}'", layout)),
+            _ => Err(anyhow!("Unexpected layout to save: '{:?}'", layout)),
         }
     }
 }

--- a/src/save_layout.rs
+++ b/src/save_layout.rs
@@ -1,0 +1,241 @@
+/*
+    Copyright (C) 2022  Biagio Festa
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+use crate::command_executor::CommandExecutor;
+use crate::command_executor::I3Node;
+use crate::utilities::find_workspace_by_num;
+use crate::utilities::query_workspace_focused;
+use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Result;
+use bincode::Options as BinCodeOptions;
+use i3_ipc::reply::NodeLayout as I3NodeLayout;
+use i3_ipc::reply::NodeType as I3NodeType;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::io::Read;
+use std::io::Write;
+
+type NodeId = usize;
+type NodeIndex = usize;
+type WorkspaceNum = i32;
+
+pub struct SaveLayout {
+    command_executor: CommandExecutor,
+}
+
+impl SaveLayout {
+    pub fn new(command_executor: CommandExecutor) -> Self {
+        Self { command_executor }
+    }
+
+    pub fn execute<W>(
+        mut self,
+        workspace_num: Option<i32>,
+        output: W,
+        json_output: bool,
+    ) -> Result<()>
+    where
+        W: Write,
+    {
+        let root_node = self.command_executor.query_root_node()?;
+
+        let workspace = match workspace_num {
+            Some(workspace_num) => find_workspace_by_num(&root_node, workspace_num)
+                .ok_or_else(|| anyhow!("Cannot find the workspace number '{}'", workspace_num))?,
+            None => query_workspace_focused(&root_node, &mut self.command_executor)?,
+        };
+
+        Self::save_subtree(workspace)?.serialize(output, json_output)
+    }
+
+    fn save_subtree(subtree: &I3Node) -> Result<SavedLayout> {
+        let mut nodes = vec![];
+        let mut dfs = vec![subtree];
+
+        while let Some(current) = dfs.pop() {
+            nodes.push(SavedNode {
+                id: current.id,
+                kind: KindNode::new(current)?,
+                layout: current.layout.try_into()?,
+                children: current.nodes.iter().map(|node| node.id).collect(),
+            });
+
+            dfs.extend(current.nodes.as_slice());
+        }
+
+        Ok(SavedLayout::new(SavedNodes(nodes)))
+    }
+}
+
+pub struct SavedLayout {
+    nodes: SavedNodes,
+    map_id: HashMap<NodeId, NodeIndex>,
+}
+
+impl SavedLayout {
+    fn new(nodes: SavedNodes) -> Self {
+        let map_id = nodes
+            .0
+            .iter()
+            .enumerate()
+            .map(|(index, node)| (node.id, index))
+            .collect();
+
+        Self { nodes, map_id }
+    }
+
+    pub fn serialize<W>(&self, output: W, json_output: bool) -> Result<()>
+    where
+        W: Write,
+    {
+        if json_output {
+            let mut serializer = serde_json::ser::Serializer::pretty(output);
+
+            self.nodes
+                .serialize(&mut serializer)
+                .context("Cannot JSON serialize layout")?;
+        } else {
+            let options = Self::bincode_options();
+            let mut serializer = bincode::Serializer::new(output, options);
+
+            self.nodes
+                .serialize(&mut serializer)
+                .context("Cannot binary serialize layout")?;
+        }
+
+        Ok(())
+    }
+
+    pub fn deserialize<R>(reader: R, json_input: bool) -> Result<Self>
+    where
+        R: Read,
+    {
+        let nodes = if json_input {
+            let mut deserializer = serde_json::de::Deserializer::from_reader(reader);
+
+            SavedNodes::deserialize(&mut deserializer).context("Cannot JSON deserialize layout")?
+        } else {
+            let options = Self::bincode_options();
+            let mut deserializer = bincode::de::Deserializer::with_reader(reader, options);
+
+            SavedNodes::deserialize(&mut deserializer)
+                .context("Cannot binary deserialize layout")?
+        };
+
+        Ok(Self::new(nodes))
+    }
+
+    pub fn root(&self) -> &SavedNode {
+        self.nodes
+            .0
+            .first()
+            .expect("Expected at least workspace node")
+    }
+
+    pub fn lookup_by_id(&self, node_id: usize) -> Option<&SavedNode> {
+        self.map_id
+            .get(&node_id)
+            .map(|node_index| &self.nodes.0[*node_index])
+    }
+
+    fn bincode_options() -> impl BinCodeOptions {
+        bincode::DefaultOptions::new()
+            .with_fixint_encoding()
+            .allow_trailing_bytes()
+    }
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct SavedNodes(Vec<SavedNode>);
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct SavedNode {
+    id: NodeId,
+    kind: KindNode,
+    layout: LayoutNode,
+    children: Vec<NodeId>,
+}
+
+impl SavedNode {
+    pub fn id(&self) -> NodeId {
+        self.id
+    }
+
+    pub fn kind(&self) -> &KindNode {
+        &self.kind
+    }
+
+    pub fn layout(&self) -> LayoutNode {
+        self.layout
+    }
+
+    pub fn children(&self) -> &[NodeId] {
+        self.children.as_slice()
+    }
+}
+
+#[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize)]
+pub enum LayoutNode {
+    SplitH,
+    SplitV,
+    Stacked,
+    Tabbed,
+}
+
+impl TryFrom<I3NodeLayout> for LayoutNode {
+    type Error = anyhow::Error;
+
+    fn try_from(layout: I3NodeLayout) -> Result<Self, Self::Error> {
+        match layout {
+            I3NodeLayout::SplitH => Ok(LayoutNode::SplitH),
+            I3NodeLayout::SplitV => Ok(LayoutNode::SplitV),
+            I3NodeLayout::Stacked => Ok(LayoutNode::Stacked),
+            I3NodeLayout::Tabbed => Ok(LayoutNode::Tabbed),
+            _ => Err(anyhow!("Unexpcted layout to save: '{:?}'", layout)),
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub enum KindNode {
+    Workspace(WorkspaceNum),
+    NormalWindow,
+    Splitter,
+}
+
+impl KindNode {
+    fn new(node: &I3Node) -> Result<Self> {
+        match node.node_type {
+            I3NodeType::Workspace => {
+                let workspace_num = node.num.expect("Expected workspace having 'num' field");
+                Ok(Self::Workspace(workspace_num))
+            }
+
+            I3NodeType::Con => {
+                if node.nodes.is_empty() {
+                    Ok(Self::NormalWindow)
+                } else {
+                    Ok(Self::Splitter)
+                }
+            }
+
+            _ => Err(anyhow!("Unexpected node type: '{:?}'", node.node_type)),
+        }
+    }
+}

--- a/src/tabmode.rs
+++ b/src/tabmode.rs
@@ -56,6 +56,7 @@ impl TabMode {
     /// If `workspace_num` is `None` the currently focused workspace will be used.
     pub fn execute(mut self, workspace_num: Option<i32>) -> Result<()> {
         let root_node = self.command_executor.query_root_node()?;
+
         let workspace = match workspace_num {
             Some(workspace_num) => find_workspace_by_num(&root_node, workspace_num)
                 .ok_or_else(|| anyhow!("Cannot find the workspace number '{}'", workspace_num))?,

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -31,6 +31,15 @@ pub enum Layout {
 
     /// Tabbed layout.
     Tabbed,
+
+    /// Split horizontal layout.
+    SplitH,
+
+    /// Split vertical layout.
+    SplitV,
+
+    /// Stacked layout.
+    Stacked,
 }
 
 /// A split operation request.
@@ -181,6 +190,9 @@ pub fn set_node_layout(
     let layout_cmd = match layout {
         Layout::Default => "layout default",
         Layout::Tabbed => "layout tabbed",
+        Layout::SplitH => "layout splith",
+        Layout::SplitV => "layout splitv",
+        Layout::Stacked => "layout stacked",
     };
 
     command_executor


### PR DESCRIPTION
* `save-layout [-o OUTPUT] [-w WORKSPACE_NUM] [-j]`
  * Save the layout of a single workspace (focused or input).
  * `-j` the output will be in json format (otherwise binary for best efficiency).
  * It can save on file or standard output.
 
* `restore-layout [-i INPUT] [-j]`
  * Restore a layout from a previous output of `save-layout`.